### PR TITLE
Update ods-exd-api-box dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "npTDMS>=1.10.0,<2.0.0",
-    "ods-exd-api-box>=1.3.0,<2.0.0"
+    "ods-exd-api-box>=1.5.0,<2.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pull request updates the dependency version for `ods-exd-api-box` in the `pyproject.toml` file to ensure compatibility with newer features and bug fixes.

Dependency update:

* Increased the minimum required version of `ods-exd-api-box` from `1.3.0` to `1.5.0` in the `dependencies` list in `pyproject.toml`.